### PR TITLE
Feature/GBI-2661 - Ignore case on signature validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3017,9 +3017,9 @@
             "license": "MIT"
         },
         "node_modules/base-x": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-            "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+            "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
             "license": "MIT"
         },
         "node_modules/bech32": {

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, it } from '@jest/globals'
 import { type Network } from '../config'
 import { assertTruthy, isBtcAddress, isBtcMainnetAddress, isBtcNativeSegwitAddress, isBtcTestnetAddress, isLegacyBtcAddress, isRskAddress, isRskChecksummedAddress, isSecureUrl, isTaprootAddress, isValidSignature, rskChecksum, validateRequiredFields, isBtcZeroAddress, BTC_ZERO_ADDRESS_TESTNET, BTC_ZERO_ADDRESS_MAINNET } from './validation'
+import { ethers } from 'ethers'
 
 const testnetLegacyAddresses: string[] = [
   'mi3KGJwXHCCKddxnACouP5EwYq525qcQhU',
@@ -574,6 +575,17 @@ describe('isValidSignature function should', () => {
         false
       )
     ).toBe(false)
+  })
+
+  test('return true if the signature is valid regardless of the address checksum', () => {
+    const signature = 'b00dcad964ab97d965ac473fc8bb8ceb21ce13608cdc44d7b65e9d2d2443d0535a094ec449a18ef1f1a5d91cbee5302cfa9b99556a7de3414c190a1d3e811a5b1b'
+    const address = '0x26f40996671e622A0a6408B24C0e678D93a9eFEA'
+    const quoteHash = '767aa241ab418dfca0d418fef395d85c398a4c70a6ac4ea81429cf18ef4d6038'
+    const rskChecksumAddress = rskChecksum(address, 31)
+    const ethChecksumAddress = ethers.utils.getAddress(address)
+    expect(isValidSignature(address.toLowerCase(), quoteHash, signature)).toBe(true)
+    expect(isValidSignature(rskChecksumAddress, quoteHash, signature)).toBe(true)
+    expect(isValidSignature(ethChecksumAddress, quoteHash, signature)).toBe(true)
   })
 })
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -126,7 +126,7 @@ export function isValidSignature (address: string, message: string, signature: s
   signature = signature.startsWith('0x') ? signature : '0x' + signature
   try {
     const recoveredAddress = utils.verifyMessage(parsedMessage, signature)
-    return address === recoveredAddress
+    return address.toLowerCase() === recoveredAddress.toLowerCase()
   } catch (e) {
     return false
   }


### PR DESCRIPTION
## What
Ignore the case of the address to check in `isValidSignature` function

## Why
Because a correct address is always the correct regardless of the checksum it has, so the output should still be true if the address is not checksummed

## Task
https://rsklabs.atlassian.net/browse/GBI-2661