### PR TITLE
feat: add copilot instructions and codebase patterns

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@
 ## Modules and exports
 
 - No `export default` in any `.ts` file. All exports must be named.
-- Every domain folder must have a barrel `index.ts` that uses `export *` re-exports.
+- Domain folders with multiple files use a barrel `index.ts` with `export *` re-exports (`client/`, `config/`, `utils/`, `common/`). Single-file domains (`blockchain/blockchain.ts`, `sdk/core.ts`) are re-exported directly from the root `src/index.ts` — no intermediate barrel needed.
 - The build output directory is `lib/`, not `dist/`. CI cleanup steps must use `rm -rf lib`.
 - The `initialization` subpath (`src/initialization.ts`) is a separate build target — do not re-export it from `src/index.ts`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,45 @@
+# bridges-core-sdk — Copilot Review Instructions
+
+## Errors
+
+- There is ONE custom error class in this package: `BridgeError` (in `src/client/httpClient.ts`). Do not introduce new error classes or hierarchies inside bridges-core-sdk itself. Downstream bridge SDKs (e.g. flyover-sdk) are expected to subclass `BridgeError` — that is intentional and correct.
+- Use `BridgeError` for operational/runtime failures (network, contract calls, HTTP ≥ 400, missing packages).
+- Use plain `Error` for validation and programmer errors (missing required fields, invalid config).
+- Always populate `timestamp: Date.now()`, `recoverable`, `message`, and `details` when constructing a `BridgeError`.
+- `BridgeError` wrapping a caught exception should put `e.message` inside `details` (e.g. `details: { error: e.message }`). Exception: when the full error object is needed for richer context, the whole `e` may be used instead.
+- Do not use error codes or enums inside this package — messages are free-form strings. Downstream SDKs may add their own error catalogs.
+
+## Modules and exports
+
+- No `export default` in any `.ts` file. All exports must be named.
+- Every domain folder must have a barrel `index.ts` that uses `export *` re-exports.
+- The build output directory is `lib/`, not `dist/`. CI cleanup steps must use `rm -rf lib`.
+- The `initialization` subpath (`src/initialization.ts`) is a separate build target — do not re-export it from `src/index.ts`.
+
+## HTTP and serialization
+
+- Always use `json-bigint` (the `serializer` instance in `crossFetch.ts`) to serialize POST bodies and parse responses. Never use `JSON.parse` or `JSON.stringify` directly on bridge API data — contract values can exceed JavaScript's safe integer range.
+- HTTP ≥ 400 responses must be mapped to `BridgeError` using the server's `message`, `timestamp`, `recoverable`, and `details` fields.
+
+## Validation
+
+- No Zod, Joi, Yup, or any schema validation library. All validation is hand-rolled.
+- Most boolean predicates (`isBtcAddress`, `isRskAddress`, `isBtcMainnetAddress`, etc.) must never throw — return `true`/`false` only. Exception: `isSecureUrl` throws on a structurally invalid URL string (by design — it delegates to `new URL()`). New predicates should follow the no-throw contract unless there is a strong reason to deviate.
+- Use `assertTruthy<T>` (in `src/utils/validation.ts`) to narrow `T | undefined | null` to `T`.
+- Use `validateRequiredFields` for checking required object properties; it throws plain `Error`.
+
+## Configuration
+
+- All per-bridge config interfaces must extend `BridgesConfig` from `src/config/index.ts`.
+- Common fields (`network`, `allowInsecureConnections`, `rskConnection`) must not be duplicated in per-bridge configs — they are merged by `getConfig()` in `initialization.ts`.
+- Captcha resolution must be injected as `captchaTokenResolver: () => Promise<string>`, never hardcoded.
+
+## Constants
+
+- Exported constant objects must be wrapped with `deepFreeze(... as const)`.
+- Module-private constants use `SCREAMING_SNAKE_CASE`. Exported constants also use `SCREAMING_SNAKE_CASE`.
+
+## Async
+
+- Do not write `return await promise` outside of a `try` block — ESLint enforces `no-return-await`.
+- Use dynamic `import()` for lazily loading bridge SDK packages in `initialization.ts`.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,107 @@
+---
+applyTo: "src/**/*.test.ts"
+---
+
+# Test Conventions — bridges-core-sdk
+
+## File placement
+
+Test files are co-located with their source file in the same directory:
+
+```
+src/blockchain/blockchain.ts
+src/blockchain/blockchain.test.ts   ✓ correct
+src/__tests__/blockchain.test.ts    ✗ wrong
+```
+
+## Imports
+
+Always use `@jest/globals` explicit imports — never rely on Jest globals:
+
+```typescript
+import { describe, test, expect, jest, beforeAll, beforeEach } from '@jest/globals'
+```
+
+## describe / test naming
+
+The word **"should"** belongs in the `describe` block, not in the `test` name:
+
+```typescript
+// correct
+describe('validateRequiredFields function should', () => {
+  test('throw if a required field is missing', () => { ... })
+  test('not throw when all fields are present', () => { ... })
+})
+
+// wrong
+describe('validateRequiredFields', () => {
+  it('should throw if a required field is missing', () => { ... })
+})
+```
+
+## Asserting async errors — prefer `.rejects`
+
+Use `.rejects.toThrow()` or `.rejects.toMatchObject()` for async error assertions. Do not use `try/catch` in tests unless you need to assert on both the error class and its properties simultaneously — in that case guard with `expect.assertions(n)`:
+
+```typescript
+// preferred
+await expect(callContractFunction(mock, 'failMethod')).rejects.toThrow(BridgeError)
+
+// acceptable only when asserting class + properties
+expect.assertions(3)
+await callContractFunction(mock, 'failMethod').catch(e => {
+  expect(e).toBeInstanceOf(BridgeError)
+  expect(e.recoverable).toBe(true)
+  expect(e.details).toMatchObject({ ... })
+})
+
+// wrong — bare try/catch
+try {
+  await callContractFunction(mock, 'failMethod')
+} catch (e) {
+  expect(e).toBeInstanceOf(BridgeError)
+}
+```
+
+## Mocking
+
+Module mocks are declared at the top of the file with `jest.mock`:
+
+```typescript
+jest.mock('ethers')
+jest.mock('cross-fetch')
+```
+
+Use `jest.spyOn` for partial mocks when you only want to override one method:
+
+```typescript
+const spy = jest.spyOn(bech32m, 'decode')
+```
+
+Manual mock objects for complex types (ethers signer, provider, contract) are defined as `any` and reset in `beforeEach`.
+
+## Lifecycle hooks
+
+| Hook | When to use |
+|---|---|
+| `beforeAll` | Create shared instances (e.g. `BlockchainConnection`) or heavy mocks used across all tests |
+| `beforeEach` | Reset per-test state (e.g. mock return values, counters) |
+| `afterEach` | `jest.clearAllMocks()` when mocks need explicit clearing |
+| `afterAll` | Not used in this repo |
+
+## Assertions reference
+
+| Pattern | Use |
+|---|---|
+| `expect(x).toBe(y)` | Primitives, booleans, reference equality |
+| `expect(x).toEqual(y)` | Deep equality for objects and arrays |
+| `expect(x).toBeInstanceOf(BridgeError)` | Error type checks |
+| `expect(() => fn()).toThrow(BridgeError)` | Synchronous throws |
+| `await expect(p).rejects.toThrow(BridgeError)` | Async throws (preferred) |
+| `expect(mock).toHaveBeenCalledTimes(n)` | Mock call count |
+| `it.each([...])('%s', ...)` | Parameterised input variants |
+
+## Integration tests
+
+Integration tests live in `integration-test/` (a separate npm package), not in `src/`.
+They are never run in CI — they require a live network. Do not add network calls or real RPC usage to `src/**/*.test.ts`.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -99,7 +99,7 @@ Manual mock objects for complex types (ethers signer, provider, contract) are de
 | `expect(() => fn()).toThrow(BridgeError)` | Synchronous throws |
 | `await expect(p).rejects.toThrow(BridgeError)` | Async throws (preferred) |
 | `expect(mock).toHaveBeenCalledTimes(n)` | Mock call count |
-| `it.each([...])('%s', ...)` | Parameterised input variants |
+| `it.each([...])('%s', ...)` | Parameterised input variants (import `it` from `@jest/globals`) |
 
 ## Integration tests
 

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -68,8 +68,8 @@ Use generics sparingly. Appropriate uses: type-narrowing assertions, generic ret
 
 ## Strict compliance
 
-- No `any` outside of catch blocks, test mocks, or `BridgeError.details`.
-- All `noUnused*`, `noImplicit*`, and `noUncheckedIndexedAccess` flags are enabled — do not suppress them with `// @ts-ignore` or `// eslint-disable`.
+- Avoid `any` in new code. Existing accepted uses: `catch (e: any)`, test mocks, `BridgeError.details`, function parameters that are genuinely untyped at the boundary (e.g. encrypted JSON input), `response.json()` parsing, and `as any` casts needed to satisfy the type checker on complex generics (e.g. `bridges[bridgeName] = bridge as any`, `(obj as any)[key]`).
+- The repo uses narrowly-scoped `// eslint-disable-next-line` for specific rules (e.g. `@typescript-eslint/no-non-null-assertion`). Do not flag these as violations. Broad `// eslint-disable` file-level disables are not acceptable.
 
 ## Naming
 

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,90 @@
+---
+applyTo: "src/**/*.ts"
+---
+
+# TypeScript Conventions — bridges-core-sdk
+
+## Types vs interfaces
+
+- Use `interface` for object shapes, class `implements` targets, and config hierarchies.
+- Use `type` for union literals, mapped types, and function signatures.
+
+```typescript
+// correct
+export type Network = 'Mainnet' | 'Testnet' | 'Regtest' | 'Alphanet' | 'Development'
+export type CaptchaTokenResolver = () => Promise<string>
+export interface HttpClient { get: <T>(...) => Promise<T> }
+
+// wrong — union as interface, contract as type
+export interface Network { }
+export type HttpClient = { get: ... }
+```
+
+## Type-only imports
+
+Always use inline `type` keyword for type-only imports:
+
+```typescript
+import { type BridgesConfig } from '.'
+import { type CaptchaTokenResolver } from '../client'
+```
+
+## Class design
+
+- Use **private constructor + static async factory methods** for classes whose construction can fail asynchronously. Note: downstream SDKs (e.g. flyover-sdk) may use public constructors with their own initialization logic — that is correct for those packages. Within bridges-core-sdk, prefer the static factory pattern:
+
+```typescript
+export class BlockchainConnection implements Connection {
+  private constructor (private readonly _signer: Signer) {}
+
+  static async createUsingRpc (rpcUrl: string): Promise<BlockchainConnection> { ... }
+}
+```
+
+- Use a **factory function returning an object literal** when a class adds no value:
+
+```typescript
+export function getHttpClient (resolver: CaptchaTokenResolver): HttpClient {
+  return {
+    getCaptchaToken: resolver,
+    async get<T>(url: string): Promise<T> { ... }
+  }
+}
+```
+
+- Private backing fields use underscore prefix and are exposed via a public getter:
+
+```typescript
+private readonly _signer: Signer
+get signer (): Signer { return this._signer }
+```
+
+- Use `implements` against an interface. Do not extend other domain classes.
+- No abstract classes. No decorators.
+
+## Generics
+
+Use generics sparingly. Appropriate uses: type-narrowing assertions, generic return types on interface methods, `deepFreeze<T>`.
+
+## Strict compliance
+
+- No `any` outside of catch blocks, test mocks, or `BridgeError.details`.
+- All `noUnused*`, `noImplicit*`, and `noUncheckedIndexedAccess` flags are enabled — do not suppress them with `// @ts-ignore` or `// eslint-disable`.
+
+## Naming
+
+| Thing | Convention |
+|---|---|
+| Files | camelCase (`crossFetch.ts`, `httpClient.ts`) |
+| Classes / Interfaces | PascalCase |
+| Functions / variables | camelCase |
+| Private fields | `_camelCase` (underscore prefix) |
+| Module-private constants | `SCREAMING_SNAKE_CASE` |
+| Exported constants | `SCREAMING_SNAKE_CASE` |
+| Exported constant objects | camelCase, wrapped in `deepFreeze(... as const)` |
+
+## CI and build
+
+- Build output is `lib/`. Any cleanup step must use `rm -rf lib`, never `rm -rf dist`.
+- GitHub Actions must be pinned by full commit SHA with a `# vX.Y.Z` comment.
+- Declare the minimum-privilege `permissions` block on every workflow job.

--- a/codebase-patterns.md
+++ b/codebase-patterns.md
@@ -1,0 +1,671 @@
+# bridges-core-sdk — Codebase Patterns Reference
+
+This document captures the architectural decisions, coding conventions, and design patterns
+used in `@rsksmart/bridges-core-sdk`. Intended as a reference for LLM rules and onboarding.
+
+---
+
+## 1. Project Structure
+
+The repository is organized by **domain** under `src/`. Each domain folder owns its
+source, types, and tests. There are no feature slices or layer slices.
+
+```
+src/
+├── index.ts              ← main public barrel
+├── initialization.ts     ← separate subpath entry (@rsksmart/bridges-core-sdk/initialization)
+├── sdk/core.ts           ← Bridge interface, BridgeMetadata, Fee types
+├── blockchain/           ← BlockchainConnection, BlockchainReadOnlyConnection, tx helpers
+├── client/               ← HttpClient interface, BridgeError, cross-fetch implementation
+├── config/               ← Network type, BridgesConfig, per-bridge config interfaces
+├── common/               ← shared immutable constants (tokens)
+└── utils/                ← pure helpers: validation, parsing, mutability
+```
+
+**Build output** goes to `lib/` (not `dist/`). Only `lib/` artifacts are published.
+
+**`integration-test/`** is a **separate private npm package** — it has its own `package.json`,
+`jest.config.js`, and ESLint config. It imports the SDK by package name, not relative path.
+Integration tests are **not run in CI**; they require a live network.
+
+---
+
+## 2. TypeScript Style
+
+### Strict compiler flags (non-negotiable)
+
+Both `core.tsconfig.json` and `initialization.tsconfig.json` enable full strict mode plus:
+
+```json
+"noUnusedLocals": true,
+"noUnusedParameters": true,
+"noImplicitReturns": true,
+"noFallthroughCasesInSwitch": true,
+"noUncheckedIndexedAccess": true,
+"noImplicitOverride": true
+```
+
+Target: `es2016`. Module: `ES2022`. `moduleResolution: Node16`.
+
+### Interfaces for contracts, types for unions and mapped types
+
+- **Interfaces**: object shapes, class `implements` targets, config hierarchies
+- **Types**: union literals, mapped types, function signatures
+
+```typescript
+// type for union literal
+export type Network = 'Mainnet' | 'Testnet' | 'Regtest' | 'Alphanet' | 'Development'
+
+// type for function signature
+export type CaptchaTokenResolver = () => Promise<string>
+
+// type for mapped shape
+export type BridgesInitializations = {
+  [key in keyof AllBridgesConfigs]: Omit<AllBridgesConfigs[key], keyof BridgesConfig>
+}
+
+// interface for contract
+export interface HttpClient {
+  get: <T>(url: string, options?: Partial<HttpClientOptions>) => Promise<T>
+  post: <T>(url: string, body: object, options?: Partial<HttpClientOptions>) => Promise<T>
+  getCaptchaToken: CaptchaTokenResolver
+}
+```
+
+### Type-only imports
+
+Always use `import { type Foo }` for type-only imports:
+
+```typescript
+import { type BridgesConfig } from '.'
+import { type CaptchaTokenResolver } from '../client'
+```
+
+### No decorators
+
+Zero `@` decorator usage anywhere in `src/`.
+
+### `any` usage
+
+`any` appears only in:
+- `catch` blocks (`catch (e: any)`)
+- Test mocks (e.g. `contractMock: any`)
+- `BridgeError.details` field (intentionally loose)
+
+Do not introduce `any` elsewhere.
+
+---
+
+## 3. Naming Conventions
+
+| Thing | Convention | Example |
+|---|---|---|
+| Source files | camelCase | `crossFetch.ts`, `httpClient.ts` |
+| Folders | lowercase | `client/`, `utils/`, `config/` |
+| Test files | `*.test.ts` co-located | `blockchain.test.ts` |
+| Classes | PascalCase | `BlockchainConnection`, `BridgeError` |
+| Interfaces | PascalCase | `HttpClient`, `Connection`, `Bridge` |
+| Functions | camelCase verbs | `getHttpClient`, `validateRequiredFields` |
+| Private fields | `_camelCase` with underscore prefix | `_signer`, `_provider` |
+| Module-private constants | `SCREAMING_SNAKE_CASE` | `RSK_ADDRESS_REGEX`, `DEFAULT_NODE_URL` |
+| Exported constants | `SCREAMING_SNAKE_CASE` | `BTC_ZERO_ADDRESS_MAINNET` |
+| Exported constant objects | camelCase | `tokens` |
+| Network/union members | PascalCase strings | `'Mainnet'`, `'Testnet'` |
+
+---
+
+## 4. Error Handling
+
+### Single error class: `BridgeError`
+
+There is **one** custom error class. No deep hierarchy, no error codes enum.
+
+```typescript
+export class BridgeError extends Error {
+  timestamp: number
+  recoverable: boolean
+  details: any
+  serverUrl?: string
+  product?: string
+  constructor (args: ErrorDetails) {
+    super(args.message)
+    // ...
+  }
+}
+```
+
+### When to use `BridgeError` vs plain `Error`
+
+| Situation | Use |
+|---|---|
+| Operational/runtime failures (network, contract, HTTP ≥ 400) | `BridgeError` |
+| Developer/programming errors (validation, missing config fields) | plain `Error` |
+| Initialization with missing package | `BridgeError` with `recoverable: false` |
+
+### Four creation patterns
+
+**1. Private factory function** (wraps caught errors):
+```typescript
+function connectionError (e: Error): BridgeError {
+  return new BridgeError({
+    timestamp: Date.now(),
+    recoverable: true,
+    message: 'error getting authenticated signer',
+    details: { error: e.message }
+  })
+}
+```
+
+**2. Direct `throw new BridgeError({...})`** in domain logic:
+```typescript
+throw new BridgeError({
+  timestamp: Date.now(),
+  recoverable: true,
+  message,
+  details: { txHash: txResult.txHash }
+})
+```
+
+**3. HTTP error mapped from server JSON** (server fields passed through):
+```typescript
+throw new BridgeError({
+  serverUrl: response.url,
+  message: responseBody.message,
+  timestamp: responseBody.timestamp,
+  recoverable: responseBody.recoverable,
+  details: responseBody.details
+})
+```
+
+**4. Conversion with selective re-throw** (initialization, non-MODULE_NOT_FOUND errors bubble up):
+```typescript
+function convertToBridgeError (bridgeName: BridgeName, e: any): BridgeError {
+  if (e?.code !== 'ERR_MODULE_NOT_FOUND') {
+    throw e  // re-throw unknown errors
+  }
+  return new BridgeError({ ... })
+}
+```
+
+### Validation errors use plain `Error`
+
+```typescript
+if (missingProperties.length !== 0) {
+  throw new Error('Validation failed for object with following missing properties: ' + missingProperties.join(', '))
+}
+```
+
+### `isValidSignature` swallows errors silently
+
+Returns `false` on failure — does not throw:
+```typescript
+try {
+  const recovered = ethers.utils.recoverAddress(hash, signature)
+  return recovered.toLowerCase() === address.toLowerCase()
+} catch {
+  return false
+}
+```
+
+---
+
+## 5. Testing Style
+
+### Framework
+
+Jest + `ts-jest` preset, `@jest/globals` for explicit imports, `clearMocks: true`.
+
+```typescript
+import { describe, test, expect, jest, beforeAll, beforeEach } from '@jest/globals'
+```
+
+### File placement
+
+Tests are **co-located** with source files. No `__tests__/` directories.
+
+```
+src/blockchain/blockchain.ts
+src/blockchain/blockchain.test.ts   ← same folder
+```
+
+### Describe/test naming: `describe('X should', () => { test('behavior') })`
+
+The word **"should"** goes in the `describe` block, not the `test` name:
+
+```typescript
+describe('BlockchainConnection factories should', () => {
+  test('create connection using standard', async () => { ... })
+  test('throw error when connection fails', async () => { ... })
+})
+
+describe('validateRequiredFields function should', () => {
+  test('throw if required field is missing', () => { ... })
+  test('not throw if all required fields are present', () => { ... })
+})
+```
+
+**Do not** write `it('should create connection ...')` — put "should" in the describe.
+
+### Assertion patterns
+
+| Pattern | Use |
+|---|---|
+| `expect(x).toBe(y)` | Primitives, booleans |
+| `expect(x).toEqual(y)` | Objects, arrays |
+| `expect(x).toBeInstanceOf(BridgeError)` | Error type checks |
+| `expect(() => fn()).toThrow(BridgeError)` | Sync throws |
+| `await expect(promise).rejects.toThrow(BridgeError)` | Async throws (preferred) |
+| `expect.assertions(n)` | Guard for async `.catch()` tests |
+| `expect(mock).toHaveBeenCalledTimes(n)` | Mock call count |
+
+Prefer `.rejects.toThrow()` for async error assertions. Avoid `try/catch` in tests — only use `.catch(e => ...)` when you need to assert on both the error class and its properties simultaneously, and guard with `expect.assertions(n)`.
+
+### Mock patterns
+
+**Module mocks** at top of file:
+```typescript
+jest.mock('ethers')
+jest.mock('cross-fetch')
+```
+
+**Spy pattern** for partial mocking:
+```typescript
+const decodeBech32mSpy = jest.spyOn(bech32m, 'decode')
+```
+
+**Manual mock objects** for complex types (ethers signer, provider, contract):
+```typescript
+let contractMock: any
+beforeEach(() => {
+  contractMock = {
+    callStatic: {
+      contractMethodOk: jest.fn(),
+      contractMethodFail: jest.fn().mockImplementation(async () => {
+        throw new Error('some error')
+      })
+    }
+  }
+})
+```
+
+### Lifecycle hooks
+
+| Hook | Purpose |
+|---|---|
+| `beforeAll` | Create shared instances (e.g. `BlockchainConnection`), set up contract mocks |
+| `beforeEach` | Reset per-test state (e.g. contract mock return values) |
+| `afterEach` | `jest.clearAllMocks()` when needed |
+| `afterAll` | Not used |
+
+### Parameterized tests
+
+`it.each(...)` is used for validating many input variants (e.g. BTC address formats):
+
+```typescript
+it.each([
+  ['valid mainnet P2PKH', 'valid address', true],
+  ['invalid', 'bad address', false],
+])('%s', (_, address, expected) => {
+  expect(isBtcAddress(address)).toBe(expected)
+})
+```
+
+### No tests in CI for integration tests
+
+Integration tests (`test:integration`) run manually against a live network and are
+**excluded from CI**. They use `FailFastEnvironment` to skip remaining tests after
+the first failure and a 2-hour timeout (`EXTENDED_TIMEOUT = 7200 * 1000`).
+
+---
+
+## 6. Module & Export Patterns
+
+### Barrel exports only
+
+Every domain folder has an `index.ts` re-exporting everything:
+
+```typescript
+// src/client/index.ts
+export * from './crossFetch'
+export * from './httpClient'
+```
+
+The root `src/index.ts` re-exports all domain barrels plus `ethers`:
+
+```typescript
+export * from './sdk/core'
+export * from './blockchain/blockchain'
+export * from './config'
+export * from './common'
+export * from './utils'
+export * from './client'
+export { ethers } from 'ethers'
+```
+
+### Named exports only
+
+**No `export default`** in any `.ts` source file. All exports are named.
+
+### Subpath export for initialization
+
+`src/initialization.ts` is built as a separate entry point and exposed via:
+
+```json
+"exports": {
+  ".": "./lib/index.js",
+  "./initialization": "./lib/initialization.js"
+}
+```
+
+Consumers import it as `@rsksmart/bridges-core-sdk/initialization`.
+
+---
+
+## 7. Class Design
+
+### Composition over inheritance
+
+Classes implement interfaces but do not extend each other. Only `BridgeError extends Error`.
+
+```typescript
+export class BlockchainConnection implements Connection { ... }
+export class BlockchainReadOnlyConnection implements Connection { ... }
+// These two classes are independent — no inheritance between them
+```
+
+No abstract classes anywhere.
+
+### Private constructor + static async factories
+
+`BlockchainConnection` enforces creation through static factory methods:
+
+```typescript
+export class BlockchainConnection implements Connection {
+  private constructor (
+    private readonly _signer: Signer
+  ) {}
+
+  static async createUsingStandard (standard: providers.ExternalProvider): Promise<BlockchainConnection> { ... }
+  static async createUsingEncryptedJson (json: string, password: string): Promise<BlockchainConnection> { ... }
+  static async createUsingPassphrase (privateKey: string): Promise<BlockchainConnection> { ... }
+  static async createUsingRpc (rpcUrl: string): Promise<BlockchainConnection> { ... }
+}
+```
+
+### Private backing fields with public getters
+
+```typescript
+private readonly _signer: Signer
+
+get signer (): Signer {
+  return this._signer
+}
+```
+
+### Object literal as interface implementation
+
+`getHttpClient` returns a plain object — no class needed:
+
+```typescript
+export function getHttpClient (resolveCaptchaToken: CaptchaTokenResolver): HttpClient {
+  return {
+    getCaptchaToken: resolveCaptchaToken,
+    async get<T>(url: string, options?: Partial<HttpClientOptions>): Promise<T> { ... },
+    async post<T>(url: string, body: object, options?: Partial<HttpClientOptions>): Promise<T> { ... }
+  }
+}
+```
+
+Use a factory function returning an object literal when a class adds no value.
+
+---
+
+## 8. Async Patterns
+
+### Primary: `async/await`
+
+All public async methods use `async/await`. `.then()` is used only in internal
+implementation details, not in public-facing code.
+
+### Dynamic `import()` for lazy-loaded bridges
+
+The initialization module loads bridge packages dynamically, enabling tree-shaking
+and lazy loading:
+
+```typescript
+case 'flyover': {
+  const flyoverPkg = await import('@rsksmart/flyover-sdk')
+  return new flyoverPkg.Flyover(config as FlyoverConfig)
+}
+```
+
+Bridge SDK packages (`flyover-sdk`, `tokenbridge-sdk`) are `devDependencies` — loaded at
+runtime by consumers. If the package is missing, `convertToBridgeError` catches
+`ERR_MODULE_NOT_FOUND` and returns a friendly `BridgeError`.
+
+### `no-return-await` enforced
+
+ESLint enforces `no-return-await`. Do not write `return await promise` in non-`try` contexts.
+
+---
+
+## 9. Configuration & Initialization Patterns
+
+### Layered config interfaces (base + per-bridge extension)
+
+```typescript
+export interface BridgesConfig {
+  network: Network
+  allowInsecureConnections?: boolean
+  rskConnection?: Connection
+}
+
+export interface FlyoverConfig extends BridgesConfig {
+  captchaTokenResolver: CaptchaTokenResolver
+  customLbcAddress?: string
+  customRegtestUrl?: string
+  disableChecksum?: boolean
+}
+```
+
+New bridges add a new interface extending `BridgesConfig` in `src/config/`.
+
+### `init()` merges shared fields into per-bridge config
+
+Common fields (`network`, `allowInsecureConnections`, `rskConnection`) from the top-level
+config are spread into each bridge's specific config. Don't duplicate these fields in
+per-bridge configs.
+
+```typescript
+const config: SpecificBridgeConfig = {
+  ...particularConfig,
+  network: initConfig.network,
+  allowInsecureConnections: initConfig.allowInsecureConnections,
+  rskConnection: initConfig.rskConnection
+}
+```
+
+### Captcha resolver as injected dependency
+
+Captcha resolution is a required callback, not a hardcoded mechanism:
+
+```typescript
+captchaTokenResolver: () => Promise<string>
+```
+
+### Immutable shared constants via `deepFreeze`
+
+```typescript
+export const tokens = deepFreeze({
+  BTC: 'BTC',
+  rBTC: 'rBTC'
+} as const)
+```
+
+---
+
+## 10. Validation Patterns
+
+### No schema libraries
+
+No Zod, Joi, Yup, or class-validator. All validation is hand-rolled.
+
+### Regex-based address validation
+
+Module-level compiled regexes, tested with `.some(regex => regex.test(address))`:
+
+```typescript
+export function isBtcAddress (address: string): boolean {
+  return [
+    BTC_MAINNET_P2PKH_ADDRESS_REGEX,
+    BTC_MAINNET_P2SH_ADDRESS_REGEX,
+    BTC_MAINNET_P2WPKH_ADDRESS_REGEX,
+    BTC_MAINNET_P2WSH_ADDRESS_REGEX,
+    // ...
+  ].some(regex => regex.test(address))
+}
+```
+
+### Boolean predicates vs throwing validators
+
+| Pattern | Function | Behavior |
+|---|---|---|
+| Returns boolean | `isBtcAddress`, `isRskAddress`, `isSecureUrl` | Never throws, returns `true/false` |
+| Throws on failure | `validateRequiredFields`, `assertTruthy`, `decodeBtcAddress` | Throws `Error` on invalid input |
+
+### `assertTruthy<T>` for type narrowing
+
+```typescript
+export function assertTruthy<T> (
+  value: T | undefined | null,
+  message = 'unexpected falsy value'
+): asserts value is T {
+  if (value === undefined || value === null || value === '' || value === false || value === 0 || (typeof value === 'number' && isNaN(value))) {
+    throw new Error(message)
+  }
+}
+```
+
+Use `assertTruthy` to narrow optional types to definite types after a guard check.
+
+---
+
+## 11. HTTP Client Patterns
+
+### Interface-driven, factory-created
+
+`HttpClient` is an interface. `getHttpClient(captchaTokenResolver)` is the factory.
+No `HttpClient` class exists — the return value is an object literal.
+
+### Transport
+
+`cross-fetch` provides isomorphic `fetch` (Node + browser). Import it as:
+```typescript
+import fetch from 'cross-fetch'
+```
+
+### BigInt-safe JSON serialization
+
+```typescript
+const serializer = JSONbig({ useNativeBigInt: true })
+// POST body:  serializer.stringify(body)
+// Response:   serializer.parse(text)
+```
+
+Always use `json-bigint` for serializing bridge responses — never `JSON.parse`/`JSON.stringify`
+directly, as contract values may exceed JavaScript's safe integer range.
+
+### Error mapping
+
+HTTP ≥ 400 responses are parsed as JSON and re-thrown as `BridgeError` with the server's
+fields (`message`, `timestamp`, `recoverable`, `details`, `serverUrl`).
+
+### No retry or timeout logic
+
+There is no retry, timeout, or interceptor mechanism in the HTTP client. This is intentional —
+keep the core SDK thin.
+
+---
+
+## 12. CI / GitHub Actions Patterns
+
+### All actions pinned by commit SHA
+
+```yaml
+uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.x.x
+```
+
+Always include the human-readable version as a comment alongside the SHA.
+
+### Minimum-privilege permissions model
+
+Default permissions are `contents: read`. Elevated permissions are declared only on
+the specific job that needs them:
+
+```yaml
+permissions:
+  contents: read       # default on workflow
+jobs:
+  publish:
+    permissions:
+      id-token: write  # only this job needs OIDC
+      contents: read
+```
+
+### Build output dir is `lib/`
+
+The publish workflow cleans `lib/` before building, not `dist/`:
+```yaml
+- name: Clean install dependencies
+  run: |
+    rm -rf lib
+    npm ci
+```
+
+### Pre-commit hooks
+
+The repo uses pre-commit (`.pre-commit-config.yaml`) which runs on `.ts`/`.js` changes:
+- gitleaks (secret detection)
+- shellcheck
+- trailing-whitespace
+- `npm run lint:validation`
+- `npm run test`
+
+---
+
+## 13. Documentation Conventions
+
+### JSDoc on public API only
+
+Document: class static factories, public interface fields, config interfaces.
+
+Do not document: internal/private functions, utility helpers with self-explanatory names,
+`crossFetch.ts` internals.
+
+### `@throws` tag is aspirational, not enforced
+
+The `@throws { FlyoverError }` tags in `BlockchainConnection` JSDoc reference `FlyoverError`
+but the code throws `BridgeError`. Keep `@throws` tags accurate.
+
+### Complex domain knowledge goes in test comments
+
+When a test covers non-obvious encoding logic (e.g. Bitcoin address byte layouts),
+explain it in a block comment inside the test rather than in source JSDoc.
+
+---
+
+## Quick Reference
+
+| Decision | Choice |
+|---|---|
+| Error class | Single `BridgeError`; plain `Error` for validation |
+| Test location | Co-located `*.test.ts`, no `__tests__/` |
+| Test naming | `describe('X should', () => { test('behavior') })` |
+| Async errors in tests | `.rejects.toThrow()` preferred over `try/catch` |
+| Exports | Named only, barrel `index.ts`, no `export default` |
+| Class constructors | Private + static factory when creation can fail |
+| Config | Layered interfaces extending `BridgesConfig` |
+| Validation | Hand-rolled regex/boolean predicates; `assertTruthy` for narrowing |
+| JSON | Always `json-bigint` for bridge data |
+| Build output | `lib/` (not `dist/`) |
+| CI pinning | SHA + version comment |

--- a/codebase-patterns.md
+++ b/codebase-patterns.md
@@ -87,12 +87,15 @@ Zero `@` decorator usage anywhere in `src/`.
 
 ### `any` usage
 
-`any` appears only in:
+Avoid `any` in new code. Accepted existing uses:
 - `catch` blocks (`catch (e: any)`)
 - Test mocks (e.g. `contractMock: any`)
 - `BridgeError.details` field (intentionally loose)
+- Function parameters that are genuinely untyped at the boundary (e.g. `createUsingEncryptedJson(json: any)`)
+- `response.json()` return value when parsing untyped server responses (e.g. `crossFetch.ts`)
+- `as any` casts needed to satisfy the type checker on complex generics (e.g. `bridges[bridgeName] = bridge as any`, `(obj as any)[key]` in `deepFreeze`)
 
-Do not introduce `any` elsewhere.
+Do not use `any` for laziness — only where the type is genuinely unknown or the cast is unavoidable.
 
 ---
 
@@ -299,9 +302,11 @@ beforeEach(() => {
 
 ### Parameterized tests
 
-`it.each(...)` is used for validating many input variants (e.g. BTC address formats):
+`it.each(...)` is used for validating many input variants (e.g. BTC address formats). When using `it.each`, add `it` to the `@jest/globals` import alongside `test`:
 
 ```typescript
+import { describe, test, expect, it } from '@jest/globals'
+
 it.each([
   ['valid mainnet P2PKH', 'valid address', true],
   ['invalid', 'bad address', false],
@@ -322,7 +327,7 @@ the first failure and a 2-hour timeout (`EXTENDED_TIMEOUT = 7200 * 1000`).
 
 ### Barrel exports only
 
-Every domain folder has an `index.ts` re-exporting everything:
+Domain folders with multiple files have an `index.ts` barrel re-exporting everything (`client/`, `config/`, `utils/`, `common/`). Single-file domains (`blockchain/blockchain.ts`, `sdk/core.ts`) are re-exported directly from the root `src/index.ts` — no intermediate barrel is needed for them.
 
 ```typescript
 // src/client/index.ts
@@ -424,8 +429,7 @@ Use a factory function returning an object literal when a class adds no value.
 
 ### Primary: `async/await`
 
-All public async methods use `async/await`. `.then()` is used only in internal
-implementation details, not in public-facing code.
+`async/await` is the dominant pattern. `.then()` is also used in some methods — both internal helpers and public-facing ones — when chaining a single transformation is more concise than an `async` wrapper (e.g. `getChainId()`, `get()`, `post()`, `handleResponse()`). Both styles are acceptable.
 
 ### Dynamic `import()` for lazy-loaded bridges
 


### PR DESCRIPTION
## What

Add GitHub Copilot code review configuration and a codebase patterns reference document:

- `.github/copilot-instructions.md` — repository-wide instructions that guide Copilot when reviewing PRs: error handling conventions, module/export rules, HTTP serialization, validation patterns, config structure, constants, and async rules. Kept under the 4,000-character limit enforced by Copilot code review.
- `.github/instructions/typescript.instructions.md` — path-specific instructions (applied to `src/**/*.ts`) covering TypeScript conventions: interface vs type usage, type-only imports, private constructor + static factory pattern, naming, and CI pinning rules.
- `.github/instructions/tests.instructions.md` — path-specific instructions (applied to `src/**/*.test.ts`) covering the project's testing style: co-located test files, `describe('X should')` naming, `@jest/globals` imports, preferred async error assertions, and mock patterns.
- `codebase-patterns.md` — a detailed reference document capturing all architectural decisions and conventions in the repo, used as the source of truth for writing the Copilot instructions.

## Why

Code review feedback in this repo has been sparse and inconsistent. Reviewers must currently rely on implicit knowledge of the project's conventions — error class hierarchy, BigInt-safe serialization, test naming style, static factory patterns, and more. By encoding these as Copilot instructions, every PR automatically gets a review grounded in the actual patterns the team has established, catching deviations before human review. The `codebase-patterns.md` document also serves as onboarding material and a living reference for future rule updates.