### PR TITLE
FLY-2592: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,27 @@ jobs:
         run: npm run lint:validation
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      # The secrets context is not available in a step-level `if`, so read it here
+      # and expose the result as an output. The token is never printed.
+      - name: Check for Codecov token
+        id: codecov_token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "$CODECOV_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Codecov upload skipped::CODECOV_TOKEN is not available in this repository, so the coverage report was not uploaded. Tests and coverage still ran, and CI continues normally. Forked-repository pull requests never receive secrets, so this is expected there. Add the CODECOV_TOKEN secret to enable the upload."
+            {
+              echo "### Codecov upload skipped"
+              echo
+              echo "\`CODECOV_TOKEN\` is not available, so \`coverage/lcov.info\` was not uploaded."
+              echo "Unit tests and coverage ran as usual and CI continues normally."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Upload coverage to Codecov
+        if: steps.codecov_token.outputs.present == 'true'
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,11 @@ jobs:
         run: npm ci && npm run build
       - name: Validate code format
         run: npm run lint:validation
-      - name: Run unit tests
-        run: npm run test
+      - name: Run unit tests with coverage
+        run: npm run test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rsksmart/bridges-core-sdk/badge)](https://scorecard.dev/viewer/?uri=github.com/rsksmart/bridges-core-sdk)
 [![CodeQL](https://github.com/rsksmart/bridges-core-sdk/workflows/CodeQL/badge.svg)](https://github.com/rsksmart/bridges-core-sdk/actions?query=workflow%3ACodeQL)
 [![CI](https://github.com/rsksmart/bridges-core-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/rsksmart/bridges-core-sdk/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/rsksmart/bridges-core-sdk/branch/main/graph/badge.svg)](https://codecov.io/gh/rsksmart/bridges-core-sdk)
 
 This is the core module shared by all the bridges SDKs. This has common functionality such as logic to call the blockchain, HTTP client configuration, common validations and the configuration objects to initialize each bridges product.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto    # baseline is always the current main value
+        threshold: 1%   # allow up to 1% drop before failing the check
+    patch:
+      default:
+        target: 80%     # new/changed lines in a PR must be at least 80% covered
+        threshold: 5%   # allow up to 5% below target before failing
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true  # only post a comment when coverage actually changes
+
+ignore:
+  - "**/*.test.ts"       # unit tests themselves
+  - "integration-test/**" # separate package, run by npm run test:integration
+  - "lib/**"             # build output
+  - "docs/**"            # typedoc output


### PR DESCRIPTION
## What

- Add `codecov.yml` at the repo root, using the same thresholds as `liquidity-provider-server`: project target `auto` with a 1% allowed drop, patch target 80% with a 5% allowed shortfall, and a comment that only posts when coverage changes.
- CI now runs `npm run test:coverage` in place of `npm run test`, then uploads `coverage/lcov.info` with `codecov/codecov-action`, SHA-pinned to v5.5.5 the way this repo pins every action.
- The upload step is gated on the `CODECOV_TOKEN` secret being present. Without it, CI prints a notice, writes a line to the job summary, and continues green.
- Add a Codecov badge to the README under the CI badge.

The `ignore:` list is specific to this repo: `**/*.test.ts`, `integration-test/**`, `lib/**`, `docs/**`. The Go bindings path that LPS ignores does not exist here.

Jest needed no change. `jest.config.js` already lists `lcov` in `coverageReporters`, and `.gitignore` already covers `coverage/`.

## Why

This is the shared core the Flyover SDK builds on, so a defect here reaches every SDK consumer. The repo has run `jest --coverage` for a while, but nothing uploaded the result, so a coverage regression in a PR was invisible to reviewers.

## How to verify

Run `npm run test:coverage`. It passes 434 tests across 5 suites and writes `coverage/lcov.info`, which is the path the workflow uploads.

## On the missing token

`rsksmart/bridges-core-sdk` is not onboarded to Codecov and has no repo-scoped `CODECOV_TOKEN` secret yet. That is tracked as FLY-2600 (Codecov onboarding for this repo plus the token secret), currently unassigned.

This no longer blocks the PR. A `Check for Codecov token` step reads the secret and publishes a boolean output; the upload step runs only when that output is `true`. So today CI stays green and reports:

> Codecov upload skipped: CODECOV_TOKEN is not available in this repository, so the coverage report was not uploaded. Tests and coverage still ran, and CI continues normally.

The same guard covers pull requests from forks, which never receive secrets.

`fail_ci_if_error: true` is kept for the case where the token exists, so a genuinely broken upload is still a failure rather than a silent no-op. Once the token lands, the guard passes and the step runs with no further change.

The secret goes through `env:` rather than being interpolated into the shell, and only its presence is ever printed.

## Note on the test step

I replaced the existing unit-test step rather than adding a second one, so CI does not run the suite twice. Same tests, same gate. Say so if you would rather keep both steps.

## Related issues

- Jira: [FLY-2592](https://rsklabs.atlassian.net/browse/FLY-2592)
- Parent epic: FLY-2587
- Prior art: FLY-2246, the same change on `liquidity-provider-server`
