### PR TITLE
[QA demo — do not merge] Codecov check with the changed lines covered

### DIFF
--- a/src/utils/parsing.demo.test.ts
+++ b/src/utils/parsing.demo.test.ts
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals'
+import { tryDecodeBtcAddress } from './parsing'
+
+describe('tryDecodeBtcAddress function should', () => {
+  test('return the decoded bytes for a valid address', () => {
+    expect(tryDecodeBtcAddress('bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq')).not.toBeNull()
+  })
+
+  test('return null for an address it cannot decode', () => {
+    expect(tryDecodeBtcAddress('0xa2193A393aa0c94A4d52893496F02B56C61c36A1')).toBeNull()
+  })
+})

--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -32,3 +32,13 @@ export function decodeBtcAddress (address: string, options = { keepChecksum: fal
     throw new Error('not a BTC address')
   }
 }
+
+// Demo-only helper. It exists to give the Codecov patch check some changed lines
+// to measure on a throwaway pull request. Do not merge this branch.
+export function tryDecodeBtcAddress (address: string): Uint8Array | null {
+  try {
+    return decodeBtcAddress(address)
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Throwaway pull request. **Do not merge — do not review as a code change.**

It exists only to prove the Codecov integration works on this repository, which is the Demo scenario on [FLY-2592](https://rsklabs.atlassian.net/browse/FLY-2592) (adding Codecov coverage reporting to this SDK). The Demo needs a pull request from a branch on this repository, because a fork never receives the `CODECOV_TOKEN` secret and the upload is skipped there.

## What it changes

One TypeScript file, `src/utils/parsing.ts`, gains a small helper, and `src/utils/parsing.demo.test.ts` covers it. The helper has no product purpose.

## What to check

- Codecov posts a comment on this pull request with project and patch coverage for the change.
- Two Codecov status checks appear in the check list: `codecov/project` and `codecov/patch`.
- Both are green. The changed lines are covered, so patch coverage is at or near 100%.

The companion pull request changes the same helper **without** a test, so patch coverage is 0% and the patch check goes red. Together they show that the upload runs and that the 80% patch threshold really enforces.

Close both once the Demo is signed off.
