### PR TITLE
[QA demo — do not merge] Codecov check with the changed lines uncovered

### DIFF
--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -32,3 +32,13 @@ export function decodeBtcAddress (address: string, options = { keepChecksum: fal
     throw new Error('not a BTC address')
   }
 }
+
+// Demo-only helper. It exists to give the Codecov patch check some changed lines
+// to measure on a throwaway pull request. Do not merge this branch.
+export function tryDecodeBtcAddress (address: string): Uint8Array | null {
+  try {
+    return decodeBtcAddress(address)
+  } catch {
+    return null
+  }
+}

--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -33,7 +33,7 @@ export function decodeBtcAddress (address: string, options = { keepChecksum: fal
   }
 }
 
-// Demo-only helper. It exists to give the Codecov patch check some changed lines
+// Demo-only helper, deliberately left untested. It exists to give the Codecov patch check some changed lines
 // to measure on a throwaway pull request. Do not merge this branch.
 export function tryDecodeBtcAddress (address: string): Uint8Array | null {
   try {


### PR DESCRIPTION
Throwaway pull request. **Do not merge — do not review as a code change.**

It exists only to prove the Codecov integration works on this repository, which is the Demo scenario on [FLY-2592](https://rsklabs.atlassian.net/browse/FLY-2592) (adding Codecov coverage reporting to this SDK). The Demo needs a pull request from a branch on this repository, because a fork never receives the `CODECOV_TOKEN` secret and the upload is skipped there.

## What it changes

One TypeScript file, `src/utils/parsing.ts`, gains a small helper. Nothing tests it. The helper has no product purpose.

## What to check

- Codecov posts a comment on this pull request with project and patch coverage for the change.
- Two Codecov status checks appear in the check list: `codecov/project` and `codecov/patch`.
- `codecov/patch` is **red**, and this is the expected result. The changed lines have no test, so patch coverage is 30%, below the 80% target in `codecov.yml`. A red check here is the proof that the threshold enforces instead of only reporting.

The companion pull request adds the same helper with a test, so both checks pass there.

Close both once the Demo is signed off.
